### PR TITLE
#22 Feat : 로그인 - 비밀번호 5회 이상 틀릴시 재설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/study/sharedcalendar/constant/ErrorCode.java
+++ b/src/main/java/study/sharedcalendar/constant/ErrorCode.java
@@ -1,4 +1,4 @@
-package study.constant;
+package study.sharedcalendar.constant;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
     /* 403 FORBIDDEN */
     INACTIVE_USER(HttpStatus.FORBIDDEN, "휴면 계정입니다."),
+    EXCEEDED_LOGIN_ATTEMPTS(HttpStatus.FORBIDDEN, "로그인 횟수가 초과했습니다. 비밀번호를 재설정해주세요."),
     /* 404 NOT_FOUND */
     NO_MATCHING_USER_ID(HttpStatus.NOT_FOUND, "아이디와 일치하는 유저가 없습니다."),
     NO_MATCHING_USER_PASSWORD(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/study/sharedcalendar/constant/ErrorResponse.java
+++ b/src/main/java/study/sharedcalendar/constant/ErrorResponse.java
@@ -1,4 +1,4 @@
-package study.constant;
+package study.sharedcalendar.constant;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/study/sharedcalendar/constant/UserConstant.java
+++ b/src/main/java/study/sharedcalendar/constant/UserConstant.java
@@ -1,0 +1,15 @@
+package study.sharedcalendar.constant;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "user.config")
+public class UserConstant {
+    private int maxLoginTryCount;
+    private int maxPasswordValidityPeriod;
+}

--- a/src/main/java/study/sharedcalendar/dto/LoginRes.java
+++ b/src/main/java/study/sharedcalendar/dto/LoginRes.java
@@ -8,4 +8,5 @@ public class LoginRes {
     String userId;
     String password;
     boolean activate;
+    int tryCount;
 }

--- a/src/main/java/study/sharedcalendar/dto/SignUpReq.java
+++ b/src/main/java/study/sharedcalendar/dto/SignUpReq.java
@@ -2,6 +2,8 @@ package study.sharedcalendar.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import study.sharedcalendar.constant.UserConstant;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -11,6 +13,7 @@ import javax.validation.constraints.Pattern;
 @Getter
 @Builder
 public class SignUpReq {
+
     @NotNull
     @Pattern(message = "잘못된 아이디 형식입니다."
             , regexp = "^[a-z0-9_-]{3,10}")

--- a/src/main/java/study/sharedcalendar/exception/AuthorizationException.java
+++ b/src/main/java/study/sharedcalendar/exception/AuthorizationException.java
@@ -2,7 +2,7 @@ package study.sharedcalendar.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import study.constant.ErrorCode;
+import study.sharedcalendar.constant.ErrorCode;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/study/sharedcalendar/exception/DuplicateException.java
+++ b/src/main/java/study/sharedcalendar/exception/DuplicateException.java
@@ -2,7 +2,7 @@ package study.sharedcalendar.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import study.constant.ErrorCode;
+import study.sharedcalendar.constant.ErrorCode;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/study/sharedcalendar/exception/GlobalExceptionHandler.java
+++ b/src/main/java/study/sharedcalendar/exception/GlobalExceptionHandler.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import study.constant.ErrorResponse;
+import study.sharedcalendar.constant.ErrorResponse;
 
 import javax.validation.ConstraintViolationException;
 

--- a/src/main/java/study/sharedcalendar/exception/NoMatchedUserException.java
+++ b/src/main/java/study/sharedcalendar/exception/NoMatchedUserException.java
@@ -2,7 +2,7 @@ package study.sharedcalendar.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import study.constant.ErrorCode;
+import study.sharedcalendar.constant.ErrorCode;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/study/sharedcalendar/mapper/UserMapper.java
+++ b/src/main/java/study/sharedcalendar/mapper/UserMapper.java
@@ -12,4 +12,8 @@ public interface UserMapper {
     boolean userIdExist(String userId);
 
     LoginRes findLoginUser(LoginReq loginReq);
+
+    void incrementLoginTryCount(int id);
+
+    void initLoginTryCount(int id);
 }

--- a/src/main/java/study/sharedcalendar/service/LoginService.java
+++ b/src/main/java/study/sharedcalendar/service/LoginService.java
@@ -30,17 +30,22 @@ public class LoginService {
             throw new NoMatchedUserException(NO_MATCHING_USER_ID);
         }
         if (!encryptionService.isMatch(loginReq.getPassword(), loginRes.getPassword())) {
-            if (loginRes.getTryCount() == userConstant.getMaxLoginTryCount()) {
-                throw new AuthorizationException(EXCEEDED_LOGIN_ATTEMPTS);
-            }
+            loginTryCountCheck(loginRes.getTryCount());
             userMapper.incrementLoginTryCount(loginRes.getId());
             throw new AuthorizationException(NO_MATCHING_USER_PASSWORD);
         }
         if (!loginRes.isActivate()) {
             throw new AuthorizationException(INACTIVE_USER);
         }
+        loginTryCountCheck(loginRes.getTryCount());
         userMapper.initLoginTryCount(loginRes.getId());
         setLoginSession(loginRes.getId());
+    }
+
+    private void loginTryCountCheck(int count) {
+        if (count == userConstant.getMaxLoginTryCount()) {
+            throw new AuthorizationException(EXCEEDED_LOGIN_ATTEMPTS);
+        }
     }
 
     public void setLoginSession(int id) {

--- a/src/main/java/study/sharedcalendar/service/LoginService.java
+++ b/src/main/java/study/sharedcalendar/service/LoginService.java
@@ -1,7 +1,9 @@
 package study.sharedcalendar.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import study.sharedcalendar.constant.UserConstant;
 import study.sharedcalendar.dto.LoginReq;
 import study.sharedcalendar.dto.LoginRes;
 import study.sharedcalendar.exception.AuthorizationException;
@@ -10,28 +12,34 @@ import study.sharedcalendar.mapper.UserMapper;
 
 import javax.servlet.http.HttpSession;
 
-import static study.constant.ErrorCode.*;
+import static study.sharedcalendar.constant.ErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LoginService {
     private final UserMapper userMapper;
+    private final UserConstant userConstant;
     private final EncryptionService encryptionService;
     private final HttpSession httpSession;
 
     public void login(LoginReq loginReq) {
         LoginRes loginRes = userMapper.findLoginUser(loginReq);
 
-        if (loginRes == null) {
+        if (loginRes.getUserId() == null) {
             throw new NoMatchedUserException(NO_MATCHING_USER_ID);
         }
         if (!encryptionService.isMatch(loginReq.getPassword(), loginRes.getPassword())) {
+            if (loginRes.getTryCount() == userConstant.getMaxLoginTryCount()) {
+                throw new AuthorizationException(EXCEEDED_LOGIN_ATTEMPTS);
+            }
+            userMapper.incrementLoginTryCount(loginRes.getId());
             throw new AuthorizationException(NO_MATCHING_USER_PASSWORD);
         }
         if (!loginRes.isActivate()) {
             throw new AuthorizationException(INACTIVE_USER);
         }
-
+        userMapper.initLoginTryCount(loginRes.getId());
         setLoginSession(loginRes.getId());
     }
 

--- a/src/main/java/study/sharedcalendar/service/UserService.java
+++ b/src/main/java/study/sharedcalendar/service/UserService.java
@@ -2,11 +2,12 @@ package study.sharedcalendar.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import study.sharedcalendar.constant.UserConstant;
 import study.sharedcalendar.dto.SignUpReq;
 import study.sharedcalendar.exception.DuplicateException;
 import study.sharedcalendar.mapper.UserMapper;
 
-import static study.constant.ErrorCode.*;
+import static study.sharedcalendar.constant.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -5,6 +5,7 @@ create table user (
     email varchar(45) not null,
     invite_url text not null,
     activate boolean not null,
+    try_count int not null,
     created_at timestamp not null default current_timestamp,
     updated_at timestamp not null default current_timestamp on update current_timestamp,
     primary key (id)

--- a/src/main/resources/mybatis-mapper/UserMapper.xml
+++ b/src/main/resources/mybatis-mapper/UserMapper.xml
@@ -9,13 +9,15 @@
                          email,
                          invite_url,
                          activate,
+                         try_count,
                          created_at,
                          updated_at)
         values (#{userId},
                 #{password},
                 #{email},
                 1,
-                false,
+                true,
+                0,
                 NOW(),
                 NOW());
     </insert>
@@ -29,9 +31,25 @@
     </select>
 
     <select id="findLoginUser" resultType="study.sharedcalendar.dto.LoginRes">
-        SELECT id, user_id, password, activate
+        SELECT id        AS id
+             , user_id   AS userId
+             , password  AS password
+             , activate  AS activate
+             , try_count AS tryCount
         FROM user
-        WHERE user_id=#{userId};
+        WHERE user_id = #{userId};
     </select>
+
+    <update id="incrementLoginTryCount">
+        UPDATE user
+        SET try_count = try_count + 1
+        WHERE id = #{id};
+    </update>
+
+    <update id="initLoginTryCount">
+        UPDATE user
+        SET try_count = 0
+        WHERE id = #id
+    </update>
 
 </mapper>


### PR DESCRIPTION
## 요약
- 비밀번호 5회 이상 틀릴시 재설정이 필요하다는 메시지 전송

## 변경 내용
- 아이디가 일치하고 비밀번호만 5회 이상 틀릴 시에 비밀번호를 재설정하라는 메시지를 전송합니다.
- 최대 로그인 시도 횟수는 properties 파일에 저장합니다. 
- 로그인 시도 횟수를 저장하기 위한 try_count 필드를 user 테이블에 추가합니다.
- 최대 로그인 시도 횟수를 초과한 경우 AuthroizationException(EXCEEDED_LOGIN_ATTEMPTS) 예외로 처리해줍니다. 

## Issue number/URL
#22 Feat : 로그인 - 비밀번호 5회 이상 틀릴시 재설정