### PR TITLE
#24 Feat : 로그인 - 비밀번호 90일마다 재설정

### DIFF
--- a/src/main/java/study/sharedcalendar/SharedCalendarApplication.java
+++ b/src/main/java/study/sharedcalendar/SharedCalendarApplication.java
@@ -3,9 +3,12 @@ package study.sharedcalendar;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import study.sharedcalendar.constant.UserConstant;
 
 
 @MapperScan
+@EnableConfigurationProperties(UserConstant.class)
 @SpringBootApplication
 public class SharedCalendarApplication {
 

--- a/src/main/java/study/sharedcalendar/constant/ErrorCode.java
+++ b/src/main/java/study/sharedcalendar/constant/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     /* 403 FORBIDDEN */
     INACTIVE_USER(HttpStatus.FORBIDDEN, "휴면 계정입니다."),
     EXCEEDED_LOGIN_ATTEMPTS(HttpStatus.FORBIDDEN, "로그인 횟수가 초과했습니다. 비밀번호를 재설정해주세요."),
+    EXCEEDED_PASSWORD_VALIDITY_PERIOD(HttpStatus.FORBIDDEN, "비밀번호 변경 주기가 지났습니다. 비밀번호를 재설정해주세요."),
     /* 404 NOT_FOUND */
     NO_MATCHING_USER_ID(HttpStatus.NOT_FOUND, "아이디와 일치하는 유저가 없습니다."),
     NO_MATCHING_USER_PASSWORD(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/study/sharedcalendar/constant/ErrorCode.java
+++ b/src/main/java/study/sharedcalendar/constant/ErrorCode.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {

--- a/src/main/java/study/sharedcalendar/constant/UserConstant.java
+++ b/src/main/java/study/sharedcalendar/constant/UserConstant.java
@@ -1,15 +1,18 @@
 package study.sharedcalendar.constant;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.context.properties.ConstructorBinding;
 
-@Setter
 @Getter
-@Component
 @ConfigurationProperties(prefix = "user.config")
+@ConstructorBinding
 public class UserConstant {
-    private int maxLoginTryCount;
-    private int maxPasswordValidityPeriod;
+    private final int maxLoginTryCount;
+    private final int maxPasswordValidityPeriod;
+
+    public UserConstant(int maxLoginTryCount, int maxPasswordValidityPeriod) {
+        this.maxLoginTryCount = maxLoginTryCount;
+        this.maxPasswordValidityPeriod = maxPasswordValidityPeriod;
+    }
 }

--- a/src/main/java/study/sharedcalendar/constant/UserConstant.java
+++ b/src/main/java/study/sharedcalendar/constant/UserConstant.java
@@ -1,18 +1,16 @@
 package study.sharedcalendar.constant;
 
-import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
-@Getter
 @ConfigurationProperties(prefix = "user.config")
 @ConstructorBinding
 public class UserConstant {
-    private final int maxLoginTryCount;
-    private final int maxPasswordValidityPeriod;
+    public static int MAX_LONG_TRY_COUNT;
+    public static int MAX_PASSWORD_VALIDITY_PERIOD;
 
     public UserConstant(int maxLoginTryCount, int maxPasswordValidityPeriod) {
-        this.maxLoginTryCount = maxLoginTryCount;
-        this.maxPasswordValidityPeriod = maxPasswordValidityPeriod;
+        MAX_LONG_TRY_COUNT = maxLoginTryCount;
+        MAX_PASSWORD_VALIDITY_PERIOD = maxPasswordValidityPeriod;
     }
 }

--- a/src/main/java/study/sharedcalendar/dto/User.java
+++ b/src/main/java/study/sharedcalendar/dto/User.java
@@ -1,9 +1,11 @@
 package study.sharedcalendar.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public class LoginRes {
+@AllArgsConstructor
+public class User {
     int id;
     String userId;
     String password;

--- a/src/main/java/study/sharedcalendar/mapper/UserMapper.java
+++ b/src/main/java/study/sharedcalendar/mapper/UserMapper.java
@@ -16,4 +16,6 @@ public interface UserMapper {
     void incrementLoginTryCount(int id);
 
     void initLoginTryCount(int id);
+
+    int getPasswordDateDiff(int id);
 }

--- a/src/main/java/study/sharedcalendar/mapper/UserMapper.java
+++ b/src/main/java/study/sharedcalendar/mapper/UserMapper.java
@@ -2,7 +2,7 @@ package study.sharedcalendar.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import study.sharedcalendar.dto.LoginReq;
-import study.sharedcalendar.dto.LoginRes;
+import study.sharedcalendar.dto.User;
 import study.sharedcalendar.dto.SignUpReq;
 
 @Mapper
@@ -11,7 +11,7 @@ public interface UserMapper {
 
     boolean userIdExist(String userId);
 
-    LoginRes findLoginUser(LoginReq loginReq);
+    User findLoginUser(LoginReq loginReq);
 
     void incrementLoginTryCount(int id);
 

--- a/src/main/java/study/sharedcalendar/service/LoginService.java
+++ b/src/main/java/study/sharedcalendar/service/LoginService.java
@@ -24,27 +24,31 @@ public class LoginService {
     public void login(LoginReq loginReq) {
         User user = userMapper.findLoginUser(loginReq);
 
-        if (user == null || user.getUserId() == null) {
+        if (user == null) {
             throw new NoMatchedUserException(NO_MATCHING_USER_ID);
         }
+
         if (!encryptionService.isMatch(loginReq.getPassword(), user.getPassword())) {
             loginTryCountCheck(user.getTryCount());
             userMapper.incrementLoginTryCount(user.getId());
             throw new AuthorizationException(NO_MATCHING_USER_PASSWORD);
         }
+
         if (!user.isActivate()) {
             throw new AuthorizationException(INACTIVE_USER);
         }
-        if (userMapper.getPasswordDateDiff(user.getId()) >= userConstant.getMaxPasswordValidityPeriod()) {
+
+        if (userMapper.getPasswordDateDiff(user.getId()) >= userConstant.MAX_PASSWORD_VALIDITY_PERIOD) {
             throw new AuthorizationException(EXCEEDED_PASSWORD_VALIDITY_PERIOD);
         }
+
         loginTryCountCheck(user.getTryCount());
         userMapper.initLoginTryCount(user.getId());
         setLoginSession(user.getId());
     }
 
     private void loginTryCountCheck(int count) {
-        if (count == userConstant.getMaxLoginTryCount()) {
+        if (count == userConstant.MAX_LONG_TRY_COUNT) {
             throw new AuthorizationException(EXCEEDED_LOGIN_ATTEMPTS);
         }
     }

--- a/src/main/java/study/sharedcalendar/service/LoginService.java
+++ b/src/main/java/study/sharedcalendar/service/LoginService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import study.sharedcalendar.constant.UserConstant;
 import study.sharedcalendar.dto.LoginReq;
-import study.sharedcalendar.dto.LoginRes;
+import study.sharedcalendar.dto.User;
 import study.sharedcalendar.exception.AuthorizationException;
 import study.sharedcalendar.exception.NoMatchedUserException;
 import study.sharedcalendar.mapper.UserMapper;
@@ -22,25 +22,25 @@ public class LoginService {
     private final HttpSession httpSession;
 
     public void login(LoginReq loginReq) {
-        LoginRes loginRes = userMapper.findLoginUser(loginReq);
+        User user = userMapper.findLoginUser(loginReq);
 
-        if (loginRes == null || loginRes.getUserId() == null) {
+        if (user == null || user.getUserId() == null) {
             throw new NoMatchedUserException(NO_MATCHING_USER_ID);
         }
-        if (!encryptionService.isMatch(loginReq.getPassword(), loginRes.getPassword())) {
-            loginTryCountCheck(loginRes.getTryCount());
-            userMapper.incrementLoginTryCount(loginRes.getId());
+        if (!encryptionService.isMatch(loginReq.getPassword(), user.getPassword())) {
+            loginTryCountCheck(user.getTryCount());
+            userMapper.incrementLoginTryCount(user.getId());
             throw new AuthorizationException(NO_MATCHING_USER_PASSWORD);
         }
-        if (!loginRes.isActivate()) {
+        if (!user.isActivate()) {
             throw new AuthorizationException(INACTIVE_USER);
         }
-        if (userMapper.getPasswordDateDiff(loginRes.getId()) >= userConstant.getMaxPasswordValidityPeriod()) {
+        if (userMapper.getPasswordDateDiff(user.getId()) >= userConstant.getMaxPasswordValidityPeriod()) {
             throw new AuthorizationException(EXCEEDED_PASSWORD_VALIDITY_PERIOD);
         }
-        loginTryCountCheck(loginRes.getTryCount());
-        userMapper.initLoginTryCount(loginRes.getId());
-        setLoginSession(loginRes.getId());
+        loginTryCountCheck(user.getTryCount());
+        userMapper.initLoginTryCount(user.getId());
+        setLoginSession(user.getId());
     }
 
     private void loginTryCountCheck(int count) {

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -6,6 +6,7 @@ create table user (
     invite_url text not null,
     activate boolean not null,
     try_count int not null,
+    password_date timestamp not null,
     created_at timestamp not null default current_timestamp,
     updated_at timestamp not null default current_timestamp on update current_timestamp,
     primary key (id)

--- a/src/main/resources/mybatis-mapper/UserMapper.xml
+++ b/src/main/resources/mybatis-mapper/UserMapper.xml
@@ -10,6 +10,7 @@
                          invite_url,
                          activate,
                          try_count,
+                         password_date,
                          created_at,
                          updated_at)
         values (#{userId},
@@ -18,6 +19,7 @@
                 1,
                 true,
                 0,
+                NOW(),
                 NOW(),
                 NOW());
     </insert>
@@ -49,7 +51,13 @@
     <update id="initLoginTryCount">
         UPDATE user
         SET try_count = 0
-        WHERE id = #id
+        WHERE id = #{id};
     </update>
+
+    <select id="getPasswordDateDiff" resultType="int">
+        SELECT DATEDIFF(dd, password_date, NOW()) as DATEDIFF
+        FROM user
+        WHERE id = #{id};
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis-mapper/UserMapper.xml
+++ b/src/main/resources/mybatis-mapper/UserMapper.xml
@@ -32,12 +32,12 @@
                    );
     </select>
 
-    <select id="findLoginUser" resultType="study.sharedcalendar.dto.LoginRes">
-        SELECT id        AS id
-             , user_id   AS userId
-             , password  AS password
-             , activate  AS activate
-             , try_count AS tryCount
+    <select id="findLoginUser" resultType="study.sharedcalendar.dto.User">
+        SELECT id
+             , user_id
+             , password
+             , activate
+             , try_count
         FROM user
         WHERE user_id = #{userId};
     </select>


### PR DESCRIPTION
## 요약
- 비밀번호 90일마다 재설정

## 변경 내용
- 비밀번호를 설정한 날짜를 저장하는 password_date 필드를 user 테이블에 추가합니다.
- password_date 값과 현재 날짜와 90일 이상 차이나면 AuthorizationException(EXCEEDED_PASSWORD_VALIDITY_PERIOD) 예외 처리로 비밀번호를 재설정해야 한다는 메시지를 전송합니다. 

## Issue number/URL
#24 Feat : 로그인 - 비밀번호 90일마다 재설정